### PR TITLE
#148482505 integrate travisci with badge to readme

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,3 @@
 language: node_js
 node_js: 
   - "node"
-install: npm install
-script: npm test
-after_success:
-  - npm install -g codeclimate-test-reporter
-  - cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js
-  - codeclimate-test-reporter < lcov.info

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: node_js
+node_js: 
+  - "node"
+install: npm install
+script: npm test
+after_success:
+  - npm install -g codeclimate-test-reporter
+  - cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js
+  - codeclimate-test-reporter < lcov.info

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "homepage": "https://github.com/DanielAmah/eDocCabinet#readme",
   "dependencies": {
     "babel-eslint": "^7.2.3",
+    "coveralls": "^2.13.1",
     "eslint": "^4.2.0",
     "eslint-config-airbnb": "^15.0.2",
     "eslint-plugin-import": "^2.7.0"

--- a/readme.md
+++ b/readme.md
@@ -1,1 +1,2 @@
+[![Build Status](https://travis-ci.org/DanielAmah/eDocCabinet.svg?branch=development)](https://travis-ci.org/DanielAmah/eDocCabinet)
 # Document Management System


### PR DESCRIPTION
#### What does this PR do?

Travis CI is an interface for vetting build structures. It determines if a build passes or fails. It comes with a badge to indicate the type of build.

#### Description of Task to be completed?

* Setup a .travis.yml file in the root directory.
* config the travis file and include all the settings.
* Add travis badge to readme file
#### Any background context you want to provide?

Travis integration is kind of integration known as continuous integration.

#### What are the relevant pivotal tracker stories?

Integrate Travis CI badge and attach badge to readme