### PR TITLE
chore(flight): #148482653 Integrate coverall badge to read me

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,0 +1,1 @@
+repo_token: AxxFOTS4QO4pnTzf9gAmU7qeyhuCrn8KW

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,9 @@
 language: node_js
 node_js: 
   - "node"
+install: npm install
+script: npm test
+after_success:
+  - npm install -g codeclimate-test-reporter
+  - cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js
+  - codeclimate-test-reporter < lcov.info

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,5 @@
 [![Build Status](https://travis-ci.org/DanielAmah/eDocCabinet.svg?branch=development)](https://travis-ci.org/DanielAmah/eDocCabinet)
 [![CircleCI](https://circleci.com/gh/DanielAmah/eDocCabinet.svg?style=svg)](https://circleci.com/gh/DanielAmah/eDocCabinet)
 [![Build Status](https://semaphoreci.com/api/v1/dnlamah1/edoccabinet/branches/development/badge.svg)](https://semaphoreci.com/dnlamah1/edoccabinet)
+[![Coverage Status](https://coveralls.io/repos/github/DanielAmah/eDocCabinet/badge.svg?branch=development)](https://coveralls.io/github/DanielAmah/eDocCabinet?branch=development)
 # Document Management System


### PR DESCRIPTION
#### What does this PR do?

Coveralls is a web service to help you track your code coverage over time, and ensure that all your new code is fully covered.

#### Description of Task to be completed?

* Setup a .coveralls.yml file in the root directory with token from coveralls
* configure the travis file and include settings for coveralls
* Add coveralls badge to readme file
* Any background context you want to provide?

The Coveralls service is language-agnostic and CI-agnostic, but we haven't yet built easy solutions for all the possibilities as far as repo hosting.

#### What are the relevant pivotal tracker stories?

Integrate coveralls and attach badge to readme

